### PR TITLE
vigil: adopt `FoundationEssentials` instead of `Foundation`

### DIFF
--- a/Sources/vigil/vigil.swift
+++ b/Sources/vigil/vigil.swift
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import ArgumentParser
-import Foundation
+import FoundationEssentials
 import WindowsCore
 
 private var kVigilEvent: String {


### PR DESCRIPTION
This is a reduction in the dependency structure as we only use `String.withCString(encodedAs:_:)`.