### PR TITLE
GHA: introduce a release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  id-token: write
+  contents: read
+  attestations: write
+
+jobs:
+  release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: compnerd/gha-setup-swift@main
+        with:
+          swift-version: development
+          swift-build: DEVELOPMENT-SNAPSHOT-2025-08-29-a
+          update-sdk-modules: true
+
+      - name: Build
+        run: |
+          swift build --triple aarch64-unknown-windows-msvc -debug-info-format none -c release -Xswiftc -sdk -Xswiftc ${env:SDKROOT} -Xswiftc -static-stdlib
+          swift build --triple x86_64-unknown-windows-msvc -debug-info-format none -c release -Xswiftc -sdk -Xswiftc ${env:SDKROOT} -Xswiftc -static-stdlib
+
+      - uses: anchore/sbom-action@v0
+        with:
+          path: |
+            .build/aarch64-unknown-windows-msvc/release/vigil.exe
+            .build/x86_64-unknown-windows-msvc/release/vigil.exe
+          output-file: sbom.spdx.json
+
+      - uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            .build/aarch64-unknown-windows-msvc/release/vigil.exe
+            .build/x86_64-unknown-windows-msvc/release/vigil.exe
+
+      - uses: actions/attest-sbom@v3
+        with:
+          subject-path: |
+            .build/aarch64-unknown-windows-msvc/release/vigil.exe
+            .build/x86_64-unknown-windows-msvc/release/vigil.exe
+          sbom-path: sbom.spdx.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-aarch64-vigil
+          path: .build/aarch64-unknown-windows-msvc/release/vigil.exe
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-x86_64-vigil
+          path: .build/x86_64-unknown-windows-msvc/release/vigil.exe


### PR DESCRIPTION
Add a new GHA pipeline for release builds on Windows ARM64 and AMD64. Additionally, add attestation and SBoM generation into the build.