### PR TITLE
Various reorganisation and clean up changes

### DIFF
--- a/Sources/vigil/PowerManager.swift
+++ b/Sources/vigil/PowerManager.swift
@@ -1,7 +1,7 @@
 // Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-private import WindowsCore
+internal import WindowsCore
 
 internal enum PowerManager {
   public struct PolicyInhibition {

--- a/Sources/vigil/PowerManager.swift
+++ b/Sources/vigil/PowerManager.swift
@@ -1,0 +1,37 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+private import WindowsCore
+
+internal enum PowerManager {
+  public struct PolicyInhibition {
+    public let system: Bool
+    public let display: Bool
+
+    public static func state(always: Bool, powered: Bool, display: Bool) throws -> PolicyInhibition {
+      return try Self(system: always || (powered ? PowerManager.IsOnAC : false),
+                      display: display)
+    }
+  }
+
+  public static var IsOnAC: Bool {
+    get throws {
+      var SystemPowerStatus = SYSTEM_POWER_STATUS()
+      guard GetSystemPowerStatus(&SystemPowerStatus) else {
+        throw WindowsError()
+      }
+      return SystemPowerStatus.ACLineStatus == 1
+    }
+  }
+
+  public static func inhibit(_ policy: PolicyInhibition) {
+    let state = ES_CONTINUOUS
+              | (policy.system ? ES_SYSTEM_REQUIRED : 0)
+              | (policy.display ? ES_DISPLAY_REQUIRED : 0)
+    _ = SetThreadExecutionState(state)
+  }
+
+  public static func restore() {
+    _ = SetThreadExecutionState(ES_CONTINUOUS)
+  }
+}

--- a/Sources/vigil/ProcessManagement.swift
+++ b/Sources/vigil/ProcessManagement.swift
@@ -1,0 +1,101 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import WindowsCore
+
+internal struct Job: ~Copyable {
+  internal struct Configuration {
+    fileprivate func apply(to job: inout Job) throws {
+      var LimitInformation = JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+      LimitInformation.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK
+      guard SetInformationJobObject(job.hJob, JobObjectExtendedLimitInformation,
+                                    &LimitInformation,
+                                    DWORD(MemoryLayout<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>.size)) else {
+        throw WindowsError()
+      }
+    }
+
+    internal static var `default`: Configuration {
+      Configuration()
+    }
+  }
+
+  private var hJob: HANDLE
+  private var hPort: HANDLE
+
+  internal static func create(name: String? = nil, configuration: Configuration = .default) throws -> Job {
+    // Create job object
+    let hJob = try name.withUTF16CString {
+      guard let hJob = CreateJobObjectW(nil, $0) else { throw WindowsError() }
+      return hJob
+    }
+
+    // Create completion port
+    let hPort = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nil, 0, 1)
+    guard let hPort else {
+      CloseHandle(hJob)
+      throw WindowsError()
+    }
+
+    var job = Job(hJob: hJob, hPort: hPort)
+
+    var ACPInformation = JOBOBJECT_ASSOCIATE_COMPLETION_PORT()
+    ACPInformation.CompletionKey = hJob
+    ACPInformation.CompletionPort = hPort
+    guard SetInformationJobObject(hJob, JobObjectAssociateCompletionPortInformation,
+                                  &ACPInformation,
+                                  DWORD(MemoryLayout<JOBOBJECT_ASSOCIATE_COMPLETION_PORT>.size)) else {
+      throw WindowsError()
+    }
+    try configuration.apply(to: &job)
+
+    return job
+  }
+
+  deinit {
+    CloseHandle(hJob)
+    CloseHandle(hPort)
+  }
+
+  internal func assign(process hProcess: HANDLE?) throws {
+    guard AssignProcessToJobObject(hJob, hProcess) else {
+      throw WindowsError()
+    }
+  }
+
+  internal func launch(_ command: [String]) throws -> PROCESS_INFORMATION {
+    var StartupInformation = STARTUPINFOW()
+    StartupInformation.cb = DWORD(MemoryLayout<STARTUPINFOW>.size)
+
+    var ProcessInformation = PROCESS_INFORMATION()
+
+    try quote(command).withCString(encodedAs: UTF16.self) { pwszCommandLine in
+      guard CreateProcessW(nil, UnsafeMutablePointer(mutating: pwszCommandLine), nil, nil, false,
+                            CREATE_SUSPENDED | CREATE_NEW_PROCESS_GROUP,
+                            nil, nil, &StartupInformation, &ProcessInformation) else {
+        throw WindowsError()
+      }
+    }
+
+    try assign(process: ProcessInformation.hProcess)
+
+    if Int(ResumeThread(ProcessInformation.hThread)) < 0 {
+      throw WindowsError()
+    }
+
+    return ProcessInformation
+  }
+
+  internal func `await`() {
+    var dwCompletionCode: DWORD = 0
+    var ulCompletionKey: ULONG_PTR = 0
+    var lpOverlapped: LPOVERLAPPED?
+    while GetQueuedCompletionStatus(hPort, &dwCompletionCode, &ulCompletionKey,
+                                    &lpOverlapped, INFINITE) {
+      if ulCompletionKey == ULONG_PTR(UInt(bitPattern: hJob)),
+          dwCompletionCode == JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO {
+        return
+      }
+    }
+  }
+}

--- a/Sources/vigil/Signalling.swift
+++ b/Sources/vigil/Signalling.swift
@@ -1,0 +1,61 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import WindowsCore
+
+private var kVigilEvent: String {
+  "Global\\org.compnerd.vigil.sentinel"
+}
+
+extension Vigil {
+  public static func begin() throws -> HANDLE {
+    // Create a named event that `vigil end` can signal.
+    let hEvent = kVigilEvent.withCString(encodedAs: UTF16.self) {
+      CreateEventW(nil, true, false, $0)
+    }
+    guard let hEvent else { throw WindowsError() }
+    return hEvent
+  }
+
+  public static func stand(_ hEvent: HANDLE, for duration: Duration?) throws {
+    var hEvent = hEvent
+
+    var hTimer: HANDLE?
+    if let duration {
+      let pCallback: WAITORTIMERCALLBACK = { lpParameter, _ in
+        if let hEvent = lpParameter?.assumingMemoryBound(to: HANDLE.self).pointee {
+          _ = SetEvent(hEvent)
+        }
+      }
+
+      guard CreateTimerQueueTimer(&hTimer, nil, pCallback, &hEvent,
+                                  DWORD(duration.milliseconds),
+                                  0, WT_EXECUTEINTIMERTHREAD | WT_EXECUTEONLYONCE) else {
+        throw WindowsError()
+      }
+    }
+
+    defer {
+      if let hTimer {
+        _ = DeleteTimerQueueTimer(nil, hTimer, nil)
+      }
+    }
+
+    repeat {
+      switch WaitForSingleObject(hEvent, INFINITE) {
+      case WAIT_OBJECT_0: return
+      case WAIT_FAILED: throw WindowsError()
+      default: continue
+      }
+    } while true
+  }
+
+  public static func end() throws {
+    let hEvent = kVigilEvent.withCString(encodedAs: UTF16.self) {
+      OpenEventW(EVENT_MODIFY_STATE, false, $0)
+    }
+    guard let hEvent else { throw WindowsError() }
+    defer { _ = CloseHandle(hEvent) }
+    guard SetEvent(hEvent) else { throw WindowsError() }
+  }
+}

--- a/Sources/vigil/String+Extensions.swift
+++ b/Sources/vigil/String+Extensions.swift
@@ -1,0 +1,12 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import Foundation
+
+extension Optional where Wrapped == String {
+  internal func withUTF16CString<T>(_ body: (UnsafePointer<UTF16.CodeUnit>?) throws -> T)
+      rethrows -> T {
+    guard let self else { return try body(nil) }
+    return try self.withCString(encodedAs: UTF16.self, body)
+  }
+}


### PR DESCRIPTION
This pull request refactors the `vigil` command-line tool by modularizing platform-specific logic and improving code organization. Key Windows-specific functionality—such as power management, process/job management, and signaling—has been moved into dedicated files, making the main command implementation cleaner and easier to maintain. The changes also introduce a new `SleepInhibitionOptions` struct for argument parsing and update the command implementations to use the new abstractions.

**Platform-specific logic modularization:**

* Moved power management logic into a new `PowerManager` enum in `PowerManager.swift`, including methods for checking AC power status, inhibiting/restoring sleep, and a new `PolicyInhibition` struct for policy state.
* Extracted job/process management into a new `Job` struct in `ProcessManagement.swift`, encapsulating job creation, process launching, assignment, and waiting for process completion.
* Added `Signalling.swift` with methods for signaling between `vigil` commands (`begin`, `stand`, `end`) using Windows events and timers.
* Introduced a string extension in `String+Extensions.swift` to simplify optional UTF-16 C string handling for Windows API calls.

**Command implementation refactor:**

* Refactored the main `vigil.swift` file to remove inline Windows API calls and custom logic, replacing them with calls to the new abstractions (`PowerManager`, `Job`, and signaling methods). [[1]](diffhunk://#diff-2d78544dfbaa55e04adf9337dd06088f93c083f0af6d92ae5b8c47d383cacb75L6-R8) [[2]](diffhunk://#diff-2d78544dfbaa55e04adf9337dd06088f93c083f0af6d92ae5b8c47d383cacb75L64-R51) [[3]](diffhunk://#diff-2d78544dfbaa55e04adf9337dd06088f93c083f0af6d92ae5b8c47d383cacb75L124-R67) [[4]](diffhunk://#diff-2d78544dfbaa55e04adf9337dd06088f93c083f0af6d92ae5b8c47d383cacb75L156-R88)
* Added the `SleepInhibitionOptions` struct for consistent argument parsing across commands. [[1]](diffhunk://#diff-2d78544dfbaa55e04adf9337dd06088f93c083f0af6d92ae5b8c47d383cacb75L6-R8) [[2]](diffhunk://#diff-2d78544dfbaa55e04adf9337dd06088f93c083f0af6d92ae5b8c47d383cacb75L64-R51) [[3]](diffhunk://#diff-2d78544dfbaa55e04adf9337dd06088f93c083f0af6d92ae5b8c47d383cacb75L124-R67) [[4]](diffhunk://#diff-2d78544dfbaa55e04adf9337dd06088f93c083f0af6d92ae5b8c47d383cacb75L156-R88)

These changes make the codebase more modular, readable, and maintainable, especially for future platform support or feature expansion.