### PR TITLE
GHA: rename the artifacts to avoid collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }} -R ${{ github.repository }} --draft --prerelease
-          gh release upload ${{ github.ref_name }} "${{ github.workspace }}/SourceCache/vigil/.build/aarch64-unknown-windows-msvc/release/vigil.exe#Windows ARM64" -R ${{ github.repository }}
-          gh release upload ${{ github.ref_name }} "${{ github.workspace }}/SourceCache/vigil/.build/x86_64-unknown-windows-msvc/release/vigil.exe#Windows x86_64" -R ${{ github.repository }}
-          gh release upload ${{ github.ref_name }} sbom.spdx.json -R ${{ github.repository }}
+          Copy-Item "${{ github.workspace }}/SourceCache/vigil/.build/x86_64-unknown-windows-msvc/release/vigil.exe" vigil-amd64.exe
+          Copy-Item "${{ github.workspace }}/SourceCache/vigil/.build/aarch64-unknown-windows-msvc/release/vigil.exe" vigil-arm64.exe
+
+          gh release upload ${{ github.ref_name }} "vigil-arm64.exe#Windows ARM64" -R ${{ github.repository }}
+          gh release upload ${{ github.ref_name }} "vigil-amd64.exe#Windows x86_64" -R ${{ github.repository }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
GHA only allows a single artifact with the same name. Unfortunately, this means that the artifact cannot be named `vigil.exe`, which is something the user will have to do. Instead, provide `vigil-amd64.exe` and `vigil-arm64.exe`.