### PR TITLE
vigil: add a description for the `stand` subcommand

### DIFF
--- a/Sources/vigil/vigil.swift
+++ b/Sources/vigil/vigil.swift
@@ -63,6 +63,10 @@ internal struct Vigil: ParsableCommand {
   }
 
   public struct Stand: ParsableCommand {
+    public static var configuration: CommandConfiguration {
+      CommandConfiguration(abstract: "Stand vigil, running a given command.")
+    }
+
     @OptionGroup
     private var inhibition: SleepInhibitionOptions
 


### PR DESCRIPTION
Add a description for the `stand` execution subcommand.